### PR TITLE
Proper Table Prefix 

### DIFF
--- a/src/DAO.class.php
+++ b/src/DAO.class.php
@@ -14,6 +14,7 @@ class DAO {
 	private $params;
 	private $qb;
 	private $war_config;
+	private $table;
 
 	public function __construct( $wpdb = array(), $model = array(), $params = array(), $war_config = array() ){
 		if( empty( $wpdb ) ) global $wpdb;
@@ -23,16 +24,16 @@ class DAO {
 		$this->params = $params;
 		$this->war_config = $war_config;
 		$this->qb = new Query;
+		$this->table = $this->get_table_name();
 	}
 
 	public function read_items(){
 		/** First check if the table exists, create it if not **/
-		$table = $this->db->prefix . $this->model->name;
 		$table_check = $this->create_table();
-		if( is_wp_error( $table_check ) || ! $table_check ) throw new Exception( 'Error Creating Table: ' . $table );
+		if( is_wp_error( $table_check ) || ! $table_check ) throw new Exception( 'Error Creating Table: ' . $this->table );
 
 		$help = new Global_Helpers;
-		$read_query = $this->qb->read_items_query( $table, $this->params );
+		$read_query = $this->qb->read_items_query( $this->table, $this->params );
 		$call = $this->db->get_results( $read_query );
 		if( is_wp_error( $call ) ) throw new \Exception( $call->get_error_message() );
 		if( isset( $this->model->assoc ) && ( $this->params->sideLoad || isset( $this->params->sideSearch ) ) ){
@@ -49,16 +50,17 @@ class DAO {
 	public function create_item(){
 		/** First check if the table exists, create it if not **/
 		$table_check = $this->create_table();
-		if( is_wp_error( $table_check ) || ! $table_check ) throw new Exception( 'Error Creating Table: ' . $this->db->prefix . $this->model->name );
+		if( is_wp_error( $table_check ) || ! $table_check ) throw new Exception( 'Error Creating Table: ' . $this->table );
 
 		return $this->insert_item();
 	}
 
-	public function read_item( $table = false, $find = false, $search = 'id' ){
+	// public function read_item( $table = false, $find = false, $search = 'id' ){
+	public function read_item(){
 		$help = new Global_Helpers;
-		if(! $table ) $table = $this->db->prefix . $this->model->name;
-		if( ! $find ) $find = $this->params->id;
-		$query = $this->qb->read_item_query( $table, $find, $search );
+		// if(! $table ) $table = $this->db->prefix . $this->model->name;
+		// if( ! $find ) $find = $this->params->id;
+		$query = $this->qb->read_item_query( $this->table, $this->params->id, 'id' );
 		$item = $this->db->get_row( $query );
 		if( isset( $this->model->assoc ) && ( $this->params->sideLoad || isset( $this->params->sideSearch ) ) ){
 			$params = (object)[];
@@ -70,39 +72,38 @@ class DAO {
 	}
 
 	public function update_item(){
-		$table = $this->db->prefix . $this->model->name;
 		$id = absint( trim( $this->params->id ) );
 		unset( $this->params->id );
-		$this->check_table_columns( $table );
+		$this->check_table_columns();
 		$this->unset_empty_values();
-		return $this->db->update( $this->db->prefix . $this->model->name, $this->params, [ 'id' => $id ] );
+		return $this->db->update( $this->table, $this->params, [ 'id' => $id ] );
 	}
 
 	public function delete_item(){
 		if( ! isset( $this->params->id ) ) throw new \Exceptions( 'No ID Provided' );
-		return $this->db->delete( $this->db->prefix . $this->model->name, [ 'id' => absint( trim( $this->params->id ) ) ] );
+		return $this->db->delete( $this->table, [ 'id' => absint( trim( $this->params->id ) ) ] );
 	}
 
 	private function create_table(){
-		$create_table_query = $this->qb->create_table_query( $this->db->prefix . $this->model->name, $this->model->params );
+		$create_table_query = $this->qb->create_table_query( $this->table, $this->model->params );
 		return $this->db->query( $create_table_query );
 	}
 
 	private function insert_item(){
 		$this->unset_empty_values();
 		$insert_data = $this->qb->insert_data( $this->model->params, $this->params );
-		return $this->db->insert( $this->db->prefix . $this->model->name, $insert_data );
+		return $this->db->insert( $this->table, $insert_data );
 	}
 
-	private function check_table_columns( $table ){
+	private function check_table_columns(){
 		$default_col = [ 'id', 'created_on', 'updated_on', 'user' ];
 		$model_col = array_merge( $default_col, array_keys( (array)$this->model->params ) );
-		$t_q = 'SELECT `COLUMN_NAME` FROM INFORMATION_SCHEMA.COLUMNS WHERE `TABLE_NAME` = "' . esc_sql( $table ) . '"';
+		$t_q = 'SELECT `COLUMN_NAME` FROM INFORMATION_SCHEMA.COLUMNS WHERE `TABLE_NAME` = "' . esc_sql( $this->table ) . '"';
 		$table_col = $this->db->get_col( $t_q );
 		$remove = array_values( array_diff( $table_col, $model_col ) );
 		$add = array_values( array_diff( $model_col, $table_col ) );
 
-		if( ! empty( $remove ) ) $remove_query = $this->qb->drop_col_query( $table, $remove );
+		if( ! empty( $remove ) ) $remove_query = $this->qb->drop_col_query( $this->table, $remove );
 		if( ! empty( $add ) ){
 			foreach( $add as $c ){
 				if( ! isset( $this->model->params[ $c ] ) ) continue;
@@ -110,7 +111,7 @@ class DAO {
 				$add_col[ $c ] = $this->model->params[ $c ];
 			}
 
-			if( isset( $add_col ) ) $add_query = $this->qb->add_col_query( $table, $add_col );
+			if( isset( $add_col ) ) $add_query = $this->qb->add_col_query( $this->table, $add_col );
 		}
 
 		if( isset( $remove_query ) ) $r_call = $this->db->query( $remove_query );
@@ -124,6 +125,13 @@ class DAO {
 			if( is_string( $p ) && empty( $p ) ) unset( $this->params->$k );
 		});
 		$this->params = $params;
+	}
+
+	private function get_table_name(){
+		$table = $this->db->prefix;
+		$table .= ( isset( $this->model->table_prefix ) ) ? $this->model->table_prefix : $this->war_config->api_name . '_';
+		$table .= $this->model->name;
+		return $table;
 	}
 
 }


### PR DESCRIPTION
Include either custom table_prefix variable, or the api_name as set in war_config: https://github.com/SkyPressATX/war-api/issues/14

This will make a table be either `<wp-prefix>_<api_name>_<data_model_name>` --or-- `<wp-prefix>_<table_prefix>_<data_model_name>`

`wp_api_items` --or-- `wp_custom_items`