### PR TITLE
sideLimit has been included

### DIFF
--- a/src/DAO.class.php
+++ b/src/DAO.class.php
@@ -45,6 +45,7 @@ class DAO {
 			array_walk( $call, function( &$item ){
 				$params = (object)[];
 				$params->filter = ( property_exists( $this->params, 'sideSearch' ) ) ? $this->params->sideSearch : [];
+				if( property_exists( $this->params, 'sideLimit' ) ) $params->limit = $this->params->sideLimit;
 				$da = new Data_Assoc( $this->war_config, $this->model->assoc, $params, $this->model );
 				$item = $da->get_assoc_data( $item );
 			});

--- a/src/Data_Assoc.class.php
+++ b/src/Data_Assoc.class.php
@@ -71,8 +71,6 @@ class Data_Assoc {
 	private function get_one_item( $assoc = array(), $bind = 'id', $model = false ){
 		if( ! $model ) return;
 		if( ! isset( $this->item->$model ) || empty( $this->item->$model ) ) return;
-		// if( isset( $this->params->filter ) ) unset( $this->params->filter );
-		// if( empty( $this->params ) || sizeof( $this->params ) <= 0 )
 		$this->params = (object)[ 'filter' => [] ];
 
 		$this->params->filter[] = $bind . ':eq:' . $this->item->$model;
@@ -92,11 +90,4 @@ class Data_Assoc {
 		$result = rest_do_request( $req );
 		return $result->get_data();
 	}
-
-
-
-
-
-
-
-}
+} // END Class

--- a/src/Param_Helper.class.php
+++ b/src/Param_Helper.class.php
@@ -27,6 +27,10 @@ class Param_Helper {
 			'sideSearch' => [
 				'type' => 'array',
 				// 'sanitize_callback' => [ $this, 'sanitize_side_search' ]
+			],
+			'sideLimit' => [
+				'type' => 'integer',
+				'default' => ( isset( $this->war_config->limit ) ) ? $this->war_config->limit : 10
 			]
 		];
 	}
@@ -40,6 +44,10 @@ class Param_Helper {
 			'sideSearch' => [
 				'type' => 'array',
 				// 'sanitize_callback' => [ $this, 'sanitize_side_search' ]
+			],
+			'sideLimit' => [
+				'type' => 'integer',
+				'default' => ( isset( $this->war_config->limit ) ) ? $this->war_config->limit : 10
 			]
 		];
 	}


### PR DESCRIPTION
For issue #26 sideLimit has now been included.

It can be used the same as `?limit=<x>`:

Request example:

```
http://domain.com/wp-json/test/v1/items?sideLoad=true&sideLIimit=3
```