### PR TITLE
fixing pre_return on get_records

### DIFF
--- a/src/War_Model.class.php
+++ b/src/War_Model.class.php
@@ -96,9 +96,9 @@ class War_Model {
 			$dao = new DAO( $db_info, $this->model, $request, $this->war_config );
 			$response = $dao->read_all();
 
-			if( property_exists( $this->model, 'pre_return ' ) ){
-				if( empty( $response->data ) ) return apply_filters( 'war_pre_return_' . $this->model->name, $response->data );
-				array_walk( $response->data, function( &$item ){
+			if( isset( $this->model->pre_return ) ){
+				if( empty( $response['data'] ) ) return apply_filters( 'war_pre_return_' . $this->model->name, $response->data );
+				array_walk( $response['data'], function( &$item ){
 					$item = apply_filters( 'war_pre_return_' . $this->model->name, $item );
 				});
 			}


### PR DESCRIPTION
Noticed `pre_return` was not working when `GET` to a collection, this seems to have fixed it.